### PR TITLE
Use project's launch config for port and address

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 				"@types/glob": "^7.1.1",
 				"@types/mocha": "^7.0.1",
 				"@types/node": "^12.11.7",
-				"@types/vscode": "^1.76.0",
+				"@types/vscode": "^1.88.0",
 				"@typescript-eslint/eslint-plugin": "^2.18.0",
 				"@typescript-eslint/parser": "^2.18.0",
 				"@vscode/test-cli": "^0.0.6",
@@ -264,9 +264,9 @@
 			"dev": true
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.86.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.86.0.tgz",
-			"integrity": "sha512-DnIXf2ftWv+9LWOB5OJeIeaLigLHF7fdXF6atfc7X5g2w/wVZBgk0amP7b+ub5xAuW1q7qP5YcFvOcit/DtyCQ==",
+			"version": "1.88.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.88.0.tgz",
+			"integrity": "sha512-rWY+Bs6j/f1lvr8jqZTyp5arRMfovdxolcqGi+//+cPDOh8SBvzXH90e7BiSXct5HJ9HGW6jATchbRTpTJpEkw==",
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -2,12 +2,12 @@
 	"name": "gut-extension",
 	"displayName": "gut-extension",
 	"description": "Run GUT(Godot Unit Test) tests from VSCode.",
-	"version": "2.2.1",
+	"version": "2.2.2",
 	"icon": "images/icon.png",
 	"repository": "https://github.com/bitwes/gut-extension",
 	"publisher": "bitwes",
 	"engines": {
-		"vscode": "^1.76.0"
+		"vscode": "^1.88.0"
 	},
 	"categories": [
 		"Other"
@@ -85,7 +85,7 @@
 		"@types/glob": "^7.1.1",
 		"@types/mocha": "^7.0.1",
 		"@types/node": "^12.11.7",
-		"@types/vscode": "^1.76.0",
+		"@types/vscode": "^1.88.0",
 		"@typescript-eslint/eslint-plugin": "^2.18.0",
 		"@typescript-eslint/parser": "^2.18.0",
 		"@vscode/test-cli": "^0.0.6",


### PR DESCRIPTION
Using the commands for running tests with the debugger was broken with our project. Looking into it, I think the issue is currently the VSCode extension uses the LSP port.

With this PR, I'm instead pulling the port from the workspace's launch config. To be honest I am not familiar with TypeScript or developing extensions so this change was made with the help of AI. So I'm not super confident on this specific implementation, but it seems to resolve the issue in our project.

Thanks so much for the addon and extension, super excited to use it with our project!